### PR TITLE
Chore: Drop oidc-provider-data 3rd party

### DIFF
--- a/aws/autoscaler/main.tf
+++ b/aws/autoscaler/main.tf
@@ -8,7 +8,7 @@ data "aws_eks_node_group" "node_group" {
 }
 
 locals {
-  cluster_oidc_issuer_url = flatten(concat(data.aws_eks_cluster.cluster.identity[*].oidc[0].issuer, [""]))[0]
+  cluster_oidc_issuer_url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
   autoscaling_group_name = data.aws_eks_node_group.node_group.resources.0.autoscaling_groups.0.name
 }
 

--- a/aws/autoscaler/main.tf
+++ b/aws/autoscaler/main.tf
@@ -7,13 +7,6 @@ data "aws_eks_node_group" "node_group" {
   node_group_name = "${var.cluster_name}-deployment-node-group"
 }
 
-module "oidc-provider-data" {
-  source     = "reegnz/oidc-provider-data/aws"
-  version    = "0.0.3"
-
-  issuer_url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
-}
-
 locals {
   cluster_oidc_issuer_url = flatten(concat(data.aws_eks_cluster.cluster.identity[*].oidc[0].issuer, [""]))[0]
   autoscaling_group_name = data.aws_eks_node_group.node_group.resources.0.autoscaling_groups.0.name
@@ -25,7 +18,8 @@ module "eks-cluster-autoscaler" {
 
   cluster_name                     = var.cluster_name
   cluster_identity_oidc_issuer     = local.cluster_oidc_issuer_url
-  cluster_identity_oidc_issuer_arn = module.oidc-provider-data.arn
+  cluster_identity_oidc_issuer_arn = var.eks_oidc_provider_arn
+
 
   helm_chart_version = "9.9.2"
 

--- a/aws/autoscaler/main.tf
+++ b/aws/autoscaler/main.tf
@@ -12,13 +12,18 @@ locals {
   autoscaling_group_name = data.aws_eks_node_group.node_group.resources.0.autoscaling_groups.0.name
 }
 
+module "oidc-provider-data" {
+  source = "../oidc-provider-data"
+  cluster_name = var.cluster_name
+}
+
 module "eks-cluster-autoscaler" {
   source  = "lablabs/eks-cluster-autoscaler/aws"
   version = "1.6.1"
 
   cluster_name                     = var.cluster_name
   cluster_identity_oidc_issuer     = local.cluster_oidc_issuer_url
-  cluster_identity_oidc_issuer_arn = var.eks_oidc_provider_arn
+  cluster_identity_oidc_issuer_arn = module.oidc-provider-data.arn
 
 
   helm_chart_version = "9.9.2"

--- a/aws/autoscaler/variables.tf
+++ b/aws/autoscaler/variables.tf
@@ -1,1 +1,3 @@
 variable "cluster_name" {}
+
+variable "eks_oidc_provider_arn" {}

--- a/aws/autoscaler/variables.tf
+++ b/aws/autoscaler/variables.tf
@@ -1,3 +1,1 @@
 variable "cluster_name" {}
-
-variable "eks_oidc_provider_arn" {}

--- a/aws/csi-driver/main.tf
+++ b/aws/csi-driver/main.tf
@@ -7,6 +7,11 @@ locals {
   oidc_without_http = replace(local.cluster_oidc_issuer_url, "https://", "")
 }
 
+module "oidc-provider-data" {
+  source = "../oidc-provider-data"
+  cluster_name = var.cluster_name
+}
+
 resource "aws_iam_role" "role_with_web_identity_oidc" {
   name               = "${var.cluster_name}_AmazonEKS_EFS_CSI_DriverRole"
   assume_role_policy = jsonencode({
@@ -15,7 +20,7 @@ resource "aws_iam_role" "role_with_web_identity_oidc" {
       {
         Effect : "Allow",
         Principal : {
-          "Federated" : var.eks_oidc_provider_arn
+          "Federated" : module.oidc-provider-data.arn
         },
         Action : "sts:AssumeRoleWithWebIdentity",
         Condition : {

--- a/aws/csi-driver/main.tf
+++ b/aws/csi-driver/main.tf
@@ -3,7 +3,7 @@ data "aws_eks_cluster" "cluster" {
 }
 
 locals {
-  cluster_oidc_issuer_url = flatten(concat(data.aws_eks_cluster.cluster.identity[*].oidc[0].issuer, [""]))[0]
+  cluster_oidc_issuer_url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
   oidc_without_http = replace(local.cluster_oidc_issuer_url, "https://", "")
 }
 

--- a/aws/csi-driver/main.tf
+++ b/aws/csi-driver/main.tf
@@ -2,15 +2,6 @@ data "aws_eks_cluster" "cluster" {
   name = var.cluster_name
 }
 
-module "oidc-provider-data" {
-  depends_on = [data.aws_eks_cluster.cluster]
-
-  source     = "reegnz/oidc-provider-data/aws"
-  version    = "0.0.3"
-
-  issuer_url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
-}
-
 locals {
   cluster_oidc_issuer_url = flatten(concat(data.aws_eks_cluster.cluster.identity[*].oidc[0].issuer, [""]))[0]
   oidc_without_http = replace(local.cluster_oidc_issuer_url, "https://", "")
@@ -24,7 +15,7 @@ resource "aws_iam_role" "role_with_web_identity_oidc" {
       {
         Effect : "Allow",
         Principal : {
-          "Federated" : "${module.oidc-provider-data.arn}"
+          "Federated" : var.arn
         },
         Action : "sts:AssumeRoleWithWebIdentity",
         Condition : {

--- a/aws/csi-driver/main.tf
+++ b/aws/csi-driver/main.tf
@@ -15,7 +15,7 @@ resource "aws_iam_role" "role_with_web_identity_oidc" {
       {
         Effect : "Allow",
         Principal : {
-          "Federated" : var.arn
+          "Federated" : var.eks_oidc_provider_arn
         },
         Action : "sts:AssumeRoleWithWebIdentity",
         Condition : {

--- a/aws/csi-driver/variables.tf
+++ b/aws/csi-driver/variables.tf
@@ -5,3 +5,5 @@ variable "reclaim_policy" {
 }
 
 variable "efs_id" {}
+
+variable arn {}

--- a/aws/csi-driver/variables.tf
+++ b/aws/csi-driver/variables.tf
@@ -6,4 +6,4 @@ variable "reclaim_policy" {
 
 variable "efs_id" {}
 
-variable arn {}
+variable "eks_oidc_provider_arn" {}

--- a/aws/csi-driver/variables.tf
+++ b/aws/csi-driver/variables.tf
@@ -6,4 +6,3 @@ variable "reclaim_policy" {
 
 variable "efs_id" {}
 
-variable "eks_oidc_provider_arn" {}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -36,16 +36,16 @@ module "efs" {
 }
 
 module "autoscaler" {
-  depends_on = [module.eks]
+  depends_on = [module.eks, module.oidc-provider-data]
   source     = "./autoscaler"
-
+  eks_oidc_provider_arn = module.oidc-provider-data.arn
   cluster_name = var.cluster_name
 }
 
 module "csi_driver" {
   depends_on = [module.efs, module.oidc-provider-data]
   source     = "./csi-driver"
-  arn = module.oidc-provider-data.arn
+  eks_oidc_provider_arn = module.oidc-provider-data.arn
   efs_id         = module.efs.efs_id
   reclaim_policy = var.reclaim_policy
   cluster_name   = var.cluster_name

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,10 +1,4 @@
 
-module "oidc-provider-data" {
-  depends_on = [module.eks]
-  source = "./oidc-provider-data"
-  cluster_name = var.cluster_name
-}
-
 module "vpc" {
   source = "./vpc"
 
@@ -36,16 +30,14 @@ module "efs" {
 }
 
 module "autoscaler" {
-  depends_on = [module.eks, module.oidc-provider-data]
+  depends_on = [module.eks]
   source     = "./autoscaler"
-  eks_oidc_provider_arn = module.oidc-provider-data.arn
   cluster_name = var.cluster_name
 }
 
 module "csi_driver" {
-  depends_on = [module.efs, module.oidc-provider-data]
+  depends_on = [module.efs]
   source     = "./csi-driver"
-  eks_oidc_provider_arn = module.oidc-provider-data.arn
   efs_id         = module.efs.efs_id
   reclaim_policy = var.reclaim_policy
   cluster_name   = var.cluster_name

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,7 +1,7 @@
 
 module "oidc-provider-data" {
   depends_on = [module.eks]
-  source = './oidc-provider-data'
+  source = "./oidc-provider-data"
   cluster_name = var.cluster_name
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,3 +1,10 @@
+
+module "oidc-provider-data" {
+  depends_on = [module.eks]
+  source = './oidc-provider-data'
+  cluster_name = var.cluster_name
+}
+
 module "vpc" {
   source = "./vpc"
 
@@ -36,9 +43,9 @@ module "autoscaler" {
 }
 
 module "csi_driver" {
-  depends_on = [module.efs]
+  depends_on = [module.efs, module.oidc-provider-data]
   source     = "./csi-driver"
-
+  arn = module.oidc-provider-data.arn
   efs_id         = module.efs.efs_id
   reclaim_policy = var.reclaim_policy
   cluster_name   = var.cluster_name

--- a/aws/oidc-provider-data/main.tf
+++ b/aws/oidc-provider-data/main.tf
@@ -9,6 +9,6 @@ locals {
   issuer_url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
   partition    = data.aws_partition.current.id
   account_id   = data.aws_caller_identity.current.account_id
-  url_stripped = replace(issuer_url, "https://", "")
+  url_stripped = replace(local.issuer_url, "https://", "")
   arn          = "arn:${local.partition}:iam::${local.account_id}:oidc-provider/${local.url_stripped}"
 }

--- a/aws/oidc-provider-data/main.tf
+++ b/aws/oidc-provider-data/main.tf
@@ -1,0 +1,14 @@
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+data "aws_partition" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  issuer_url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+  partition    = data.aws_partition.current.id
+  account_id   = data.aws_caller_identity.current.account_id
+  url_stripped = replace(issuer_url, "https://", "")
+  arn          = "arn:${local.partition}:iam::${local.account_id}:oidc-provider/${local.url_stripped}"
+}

--- a/aws/oidc-provider-data/outputs.tf
+++ b/aws/oidc-provider-data/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "The OIDC issuer name."
+  value       = local.url_stripped
+}
+
+output "arn" {
+  description = "The ARN that the provider will have with the given issuer URL."
+  value       = local.arn
+}

--- a/aws/oidc-provider-data/variables.tf
+++ b/aws/oidc-provider-data/variables.tf
@@ -1,0 +1,1 @@
+variable "cluster_name" {}


### PR DESCRIPTION
Bain had asked us to [fix](https://github.com/env0/k8s-modules/issues/6) some issues so they can move forward with installing shag.
This PR is one of them, here we drop `oidc-provider-data` 3rd party and implement it by ourselves. This is simply a string [manipulation](https://github.com/reegnz/terraform-aws-oidc-provider-data/blob/master/main.tf).

Tested in kushield aws org:
https://dev.dev.env0.com/p/db69cd36-e87f-4cc1-8f5c-484174962c31/environments/ee3956fd-1e85-44d1-baed-232a4e75ceba?tabname=deployment-logs