### PR TITLE
Chore: replace kubectl TF provider with kuberentes provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.cluster.token
 }
 
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint

--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.cluster.token
 }
 
-provider "kubectl" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-}
-
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint

--- a/aws/autoscaler/versions.tf
+++ b/aws/autoscaler/versions.tf
@@ -3,7 +3,5 @@ terraform {
 
   required_providers {
     aws        = "~> 3.68.0"
-    helm       = "~> 2.4.0"
-    kubernetes = "~> 2.7.0"
   }
 }

--- a/aws/autoscaler/versions.tf
+++ b/aws/autoscaler/versions.tf
@@ -4,9 +4,6 @@ terraform {
   required_providers {
     aws        = "~> 3.68.0"
     helm       = "~> 2.4.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.7.0"
-    }
+    kubernetes = "~> 2.7.0"
   }
 }

--- a/aws/csi-driver/main.tf
+++ b/aws/csi-driver/main.tf
@@ -136,8 +136,8 @@ resource "kubernetes_storage_class" "storage_class" {
     name = "env0-state-sc"
   }
   parameters = {
-    provisioningMode: "efs-ap"
-    fileSystemId: var.efs_id
-    directoryPerms: "700"
+    provisioningMode = "efs-ap"
+    fileSystemId = var.efs_id
+    directoryPerms = "700"
   }
 }

--- a/aws/csi-driver/main.tf
+++ b/aws/csi-driver/main.tf
@@ -132,6 +132,7 @@ resource "kubernetes_storage_class" "storage_class" {
 
   storage_provisioner = "efs.csi.aws.com"
   reclaim_policy = var.reclaim_policy
+  allow_volume_expansion = true
   metadata {
     name = "env0-state-sc"
   }

--- a/aws/csi-driver/versions.tf
+++ b/aws/csi-driver/versions.tf
@@ -5,5 +5,9 @@ terraform {
     aws        = "~> 3.68.0"
     kubernetes = "~> 2.7.0"
     helm       = "~> 2.4.0"
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
   }
 }

--- a/aws/csi-driver/versions.tf
+++ b/aws/csi-driver/versions.tf
@@ -5,9 +5,5 @@ terraform {
     aws        = "~> 3.68.0"
     kubernetes = "~> 2.7.0"
     helm       = "~> 2.4.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.7.0"
-    }
   }
 }

--- a/aws/eks/versions.tf
+++ b/aws/eks/versions.tf
@@ -3,6 +3,5 @@ terraform {
 
   required_providers {
     aws        = "~> 3.68.0"
-    kubernetes = "~> 2.7.0"
   }
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -7,15 +7,6 @@ data "google_container_cluster" "my_cluster" {
   location = var.cluster_location
 }
 
-provider "kubectl" {
-  host = "https://${data.google_container_cluster.my_cluster.endpoint}"
-  cluster_ca_certificate = base64decode(
-  data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,
-  )
-  token            = data.google_client_config.provider.access_token
-  load_config_file = false
-}
-
 provider "kubernetes" {
   host = "https://${data.google_container_cluster.my_cluster.endpoint}"
   cluster_ca_certificate = base64decode(

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -7,6 +7,15 @@ data "google_container_cluster" "my_cluster" {
   location = var.cluster_location
 }
 
+provider "kubectl" {
+  host = "https://${data.google_container_cluster.my_cluster.endpoint}"
+  cluster_ca_certificate = base64decode(
+  data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,
+  )
+  token            = data.google_client_config.provider.access_token
+  load_config_file = false
+}
+
 provider "kubernetes" {
   host = "https://${data.google_container_cluster.my_cluster.endpoint}"
   cluster_ca_certificate = base64decode(

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,19 +1,18 @@
 provider "google" {}
 
-// Used to configure the kubectl provider
+// Used to configure the k8s provider
 data "google_client_config" "provider" {}
 data "google_container_cluster" "my_cluster" {
   name     = var.cluster_name
   location = var.cluster_location
 }
 
-provider "kubectl" {
+provider "kubernetes" {
   host = "https://${data.google_container_cluster.my_cluster.endpoint}"
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,
+  data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,
   )
   token            = data.google_client_config.provider.access_token
-  load_config_file = false
 }
 
 module "pd_backed_nfs_server" {

--- a/gcp/pd-backed-nfs-server/README.md
+++ b/gcp/pd-backed-nfs-server/README.md
@@ -11,4 +11,4 @@ To be used for saving the env0 internal state on a persistent disk, which is nee
 1. `pv-for-deployment-pods` - The PV that the env0-agent PVC will be bound to, also using `storageClassName`.
 
 ## Providers
-Requires the `google` and `gavinbunney/kubectl` providers to be configured, see `main.tf` in parent folder.
+Requires the `google` and `kubernetes` providers to be configured, see `main.tf` in parent folder.

--- a/gcp/pd-backed-nfs-server/main.tf
+++ b/gcp/pd-backed-nfs-server/main.tf
@@ -18,11 +18,11 @@ resource "google_compute_region_disk" "env0_internal_state_disk" {
 }
 
 // K8S Manifests
-resource "kubectl_manifest" "nfs_server_deployment" {
+resource "kubernetes_manifest" "nfs_server_deployment" {
   depends_on = [
     google_compute_region_disk.env0_internal_state_disk
   ]
   for_each = toset(local.manifests)
-  yaml_body = file("${path.module}/manifests/${each.value}.yaml")
+  manifest = yamldecode(file("${path.module}/manifests/${each.value}.yaml"))
 }
 

--- a/gcp/pd-backed-nfs-server/manifests/pv-for-deployment-pods.yaml
+++ b/gcp/pd-backed-nfs-server/manifests/pv-for-deployment-pods.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: env0-nfs-pv
-  namespace: env0-agent
 spec:
   storageClassName: env0-state-sc
   capacity:

--- a/gcp/pd-backed-nfs-server/manifests/pv-for-nfs-server.yaml
+++ b/gcp/pd-backed-nfs-server/manifests/pv-for-nfs-server.yaml
@@ -15,9 +15,17 @@ spec:
     required:
       nodeSelectorTerms:
       - matchExpressions:
-        # failure-domain.beta.kubernetes.io/zone should be used prior to 1.21
         - key: topology.kubernetes.io/zone
           operator: In
           values:
           - us-central1-a
           - us-central1-b
+        - key: failure-domain.beta.kubernetes.io/zone
+          operator: In
+          values:
+          - us-central1-a
+          - us-central1-b
+        - key: failure-domain.beta.kubernetes.io/region
+          operator: In
+          values:
+          - us-central1

--- a/gcp/pd-backed-nfs-server/manifests/pv-for-nfs-server.yaml
+++ b/gcp/pd-backed-nfs-server/manifests/pv-for-nfs-server.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: env0-pv-for-nfs-server
-  namespace: env0-agent
 spec:
   storageClassName: env0-sc-for-nfs-server
   capacity:

--- a/gcp/pd-backed-nfs-server/versions.tf
+++ b/gcp/pd-backed-nfs-server/versions.tf
@@ -3,10 +3,6 @@ terraform {
 
   required_providers {
     google   = "~> 4.7.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.13.1"
-    }
     kubernetes = "~> 2.7.0"
   }
 }

--- a/gcp/pd-backed-nfs-server/versions.tf
+++ b/gcp/pd-backed-nfs-server/versions.tf
@@ -3,9 +3,6 @@ terraform {
 
   required_providers {
     google   = "~> 4.7.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.13.1"
-    }
+    kubernetes = "~> 2.7.0"
   }
 }

--- a/gcp/pd-backed-nfs-server/versions.tf
+++ b/gcp/pd-backed-nfs-server/versions.tf
@@ -3,6 +3,10 @@ terraform {
 
   required_providers {
     google   = "~> 4.7.0"
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.13.1"
+    }
     kubernetes = "~> 2.7.0"
   }
 }

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -3,10 +3,6 @@ terraform {
 
   required_providers {
     google   = "~> 4.7.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.13.1"
-    }
     kubernetes = "~> 2.7.0"
   }
 }

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -3,9 +3,6 @@ terraform {
 
   required_providers {
     google   = "~> 4.7.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.13.1"
-    }
+    kubernetes = "~> 2.7.0"
   }
 }

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -3,6 +3,10 @@ terraform {
 
   required_providers {
     google   = "~> 4.7.0"
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.13.1"
+    }
     kubernetes = "~> 2.7.0"
   }
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Remove `kubectl` TF provider in favor of the more native and official `kuberentes` provider

### Solution
1. GCP stack: 
  - Removed `kubectl` provider and switched to `kuberentes` provider (this can be done since nobody uses this stack just yet)
2. AWS stack: 
  - Replaced `csi_storage_account` and `storage_class` resources to use `kubernetes` provider instead of `kubectl` (only replaced resources, haven't removed the `kubectl` provider yet because customer use it and they need it to make the transition - otherwise `kubectl` resources would fail on destroy)
3. Removed redundant (i.e not needed) providers from `aws/autoscaler` and `aws/eks` modules.