### PR TITLE
Chore: Adding resource limits to nfs server

### DIFF
--- a/gcp/pd-backed-nfs-server/manifests/deployment.yaml
+++ b/gcp/pd-backed-nfs-server/manifests/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: nfs-pvc
+        resources:
+          limits:
+            cpu: 250m
+            memory: 1000Mi
       volumes:
         - name: nfs-pvc
           persistentVolumeClaim:


### PR DESCRIPTION
We got some feedback about not providing resource limits on the nfs server pod, which is standard and best practice for k8s. 

Checked our GKE cluster for resource usage and added these limits with some safety margin.
