### PR TITLE
Chore: refactor autoscaler module aws cli commands

### DIFF
--- a/aws/autoscaler/main.tf
+++ b/aws/autoscaler/main.tf
@@ -45,20 +45,20 @@ module "eks-cluster-autoscaler" {
 }
 
 # https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#common-notes-and-gotchas
-module "suspend_asg_processes_command" {
-  source           = "digitickets/cli/aws"
-  version          = "4.1.0"
-  aws_cli_commands = ["autoscaling", "suspend-processes", "--auto-scaling-group-name ${local.autoscaling_group_name}", "--scaling-processes AZRebalance"]
+resource "null_resource" "suspend_asg_processes_command" {
+  provisioner "local-exec" {
+    command = "aws autoscaling suspend-processes --auto-scaling-group-name ${local.autoscaling_group_name} --scaling-processes AZRebalance"
+  }
 }
 
-module "set_asg_default_cooldown_command" {
-  source           = "digitickets/cli/aws"
-  version          = "4.1.0"
-  aws_cli_commands = ["autoscaling", "update-auto-scaling-group", "--auto-scaling-group-name ${local.autoscaling_group_name}", "--default-cooldown 60"]
+resource "null_resource" "set_asg_default_cooldown_command" {
+  provisioner "local-exec" {
+    command = "aws autoscaling update-auto-scaling-group --auto-scaling-group-name ${local.autoscaling_group_name} --default-cooldown 60"
+  }
 }
 
-module "enable_asg_metrics_collection" {
-  source           = "digitickets/cli/aws"
-  version          = "4.1.0"
-  aws_cli_commands = ["autoscaling", "enable-metrics-collection ", "--auto-scaling-group-name ${local.autoscaling_group_name}", "--granularity \"1Minute\""]
+resource "null_resource" "enable_asg_metrics_collection" {
+  provisioner "local-exec" {
+    command = "aws autoscaling enable-metrics-collection --auto-scaling-group-name ${local.autoscaling_group_name} --granularity \"1Minute\""
+  }
 }


### PR DESCRIPTION
Use `local-exec` provisioner for running aws cli on managed ASG of EKS cluster instead of using `digitickets/cli/aws` 