### PR TITLE
Chore: upgrade eks cluster autoscaler

### DIFF
--- a/aws/autoscaler/main.tf
+++ b/aws/autoscaler/main.tf
@@ -26,7 +26,7 @@ module "eks-cluster-autoscaler" {
   cluster_identity_oidc_issuer_arn = module.oidc-provider-data.arn
 
 
-  helm_chart_version = "9.9.2"
+  helm_chart_version = "9.21.0"
 
   values = yamlencode({
     # Determined by our cluster version -

--- a/aws/autoscaler/main.tf
+++ b/aws/autoscaler/main.tf
@@ -19,7 +19,7 @@ module "oidc-provider-data" {
 
 module "eks-cluster-autoscaler" {
   source  = "lablabs/eks-cluster-autoscaler/aws"
-  version = "1.6.1"
+  version = "1.6.2"
 
   cluster_name                     = var.cluster_name
   cluster_identity_oidc_issuer     = local.cluster_oidc_issuer_url


### PR DESCRIPTION
Upgrade k8s CA to latest in favor of EKS 1.23 support

Upgrades:
Helm chart of autoscaler - https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler/9.21.0
TF module wrapping it - https://github.com/lablabs/terraform-aws-eks-cluster-autoscaler/releases/tag/v1.6.2

