### PR TITLE
feat: add option to write_kubeconfig

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -38,6 +38,8 @@ module "eks" {
     }
   }
 
+  write_kubeconfig = var.write_kubeconfig
+
   map_roles    = var.map_roles
   map_users    = []
   map_accounts = []

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -23,3 +23,8 @@ variable "min_capacity" {
 variable "instance_type" {
   default = "t3a.2xlarge" # 8vCPUs 32GB
 }
+
+variable "write_kubeconfig" {
+  type = bool
+  default = false 
+}


### PR DESCRIPTION
since kubeconfig isn't useful for automation environments like env0, adding option to write_kubeconfig = false