### PR TITLE
Chore: Add remote run table and table iam permission

### DIFF
--- a/log-storage/aws/dynamodb/README.md
+++ b/log-storage/aws/dynamodb/README.md
@@ -1,6 +1,6 @@
 ## DynamoDB table on your own cloud provider
 
-You can apply this module on your AWS account, to create a DynamoDB table for storing logs. env0 will assume the role created in this module, in order to read and write logs.
+You can apply this module on your AWS account, to create DynamoDB tables for storing logs. env0 will assume the role created in this module, in order to read and write logs.
 When using this module, make sure the `aws` provider is using the correct region
 
 #### Variables:

--- a/log-storage/aws/dynamodb/dynamo.tf
+++ b/log-storage/aws/dynamodb/dynamo.tf
@@ -22,3 +22,28 @@ resource "aws_dynamodb_table" "deployment_logs_table" {
     prevent_destroy = true
   }
 }
+
+resource "aws_dynamodb_table" "deployment_remote_run_logs_table" {
+  name = "deployment-step-service-${var.env0_stage}-remote-run-logs-${var.agent_key}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "deploymentLogId"
+  range_key    = "offsetStart"
+
+  attribute {
+    name = "deploymentLogId"
+    type = "S"
+  }
+
+  attribute {
+    name = "offsetStart"
+    type = "N"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/log-storage/aws/dynamodb/iam.tf
+++ b/log-storage/aws/dynamodb/iam.tf
@@ -39,6 +39,13 @@ resource "aws_iam_role" "log_reader" {
           Effect   = "Allow"
           Resource = aws_dynamodb_table.deployment_logs_table.arn
         },
+        {
+          Action   = [
+            "dynamodb:DescribeTable", "dynamodb:Query", "dynamodb:Scan", "dynamodb:GetItem", "dynamodb:BatchGetItem"
+          ]
+          Effect   = "Allow"
+          Resource = aws_dynamodb_table.deployment_remote_run_logs_table.arn
+        },
       ]
     })
   }
@@ -72,6 +79,21 @@ resource "aws_iam_role" "log_writer" {
           ]
           Effect   = "Allow"
           Resource = aws_dynamodb_table.deployment_logs_table.arn
+        },
+        {
+          Action   = [
+            "dynamodb:DescribeTable",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:GetItem",
+            "dynamodb:BatchGetItem",
+            "dynamodb:PutItem",
+            "dynamodb:UpdateItem",
+            "dynamodb:DeleteItem",
+            "dynamodb:BatchWriteItem"
+          ]
+          Effect   = "Allow"
+          Resource = aws_dynamodb_table.deployment_remote_run_logs_table.arn
         },
       ]
     })


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

In order to support Terraform remote runs we store the remote run logs on a separate logs table and then stream the logs to the user's CLI from that log table.

### Solution
Add the remote run table resources and add the table to the IAM role for the logger to be able to write into that table