### PR TITLE
wrong reference for azs in vpc

### DIFF
--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -4,7 +4,7 @@ module "vpc" {
 
   name                 = "vpc-${var.cluster_name}"
   cidr                 = var.cidr
-  azs                  = data.aws_ec2_instance_type_offerings.example.locations
+  azs                  = data.aws_ec2_instance_type_offerings.supported_azs.locations
   private_subnets      = var.private_subnets
   public_subnets       = var.public_subnets
   enable_nat_gateway   = true


### PR DESCRIPTION
`data.aws_ec2_instance_type_offerings.example.locations` doesn't work, as the `aws_ec2_instance_type_offerings` is named `supported_azs`, changed to `data.aws_ec2_instance_type_offerings.supported_azs.locations`