### PR TITLE
Fix: drop usage of non existent stage var

### DIFF
--- a/log-storage/aws/dynamodb/dynamo.tf
+++ b/log-storage/aws/dynamodb/dynamo.tf
@@ -24,7 +24,7 @@ resource "aws_dynamodb_table" "deployment_logs_table" {
 }
 
 resource "aws_dynamodb_table" "deployment_remote_run_logs_table" {
-  name = "deployment-step-service-${var.env0_stage}-remote-run-logs-${var.agent_key}"
+  name = "deployment-step-service-prod-remote-run-logs-${var.agent_key}"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "deploymentLogId"
   range_key    = "offsetStart"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
remote run logs tables used a non existing variable `env0_stage`, it should have just been `prod` like we have for the deployment logs table

### Solution
Drop the stage var and have it be 'prod' instead

### How I _manually_ verified it works
- [x] run a terraform plan locally and see that no errors go out