### PR TITLE
CHORE: bump required versions

### DIFF
--- a/aws/autoscaler/versions.tf
+++ b/aws/autoscaler/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws        = "~> 3.68.0"
+    aws        = ">= 3.68.0"
   }
 }

--- a/aws/autoscaler/versions.tf
+++ b/aws/autoscaler/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws        = ">= 3.68.0"
+    aws        = ">= 4.0.0"
   }
 }

--- a/aws/csi-driver/versions.tf
+++ b/aws/csi-driver/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws        = "~> 3.68.0"
+    aws        = ">= 4.0.0"
     kubernetes = "~> 2.11.0"
     helm       = "~> 2.10.1"
     kubectl = {

--- a/aws/csi-driver/versions.tf
+++ b/aws/csi-driver/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws        = ">= 4.0.0"
-    kubernetes = "~> 2.11.0"
+    kubernetes = ">= 2.11.0"
     helm       = "~> 2.10.1"
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/aws/csi-driver/versions.tf
+++ b/aws/csi-driver/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws        = "~> 3.68.0"
-    kubernetes = "~> 2.7.0"
-    helm       = "~> 2.4.0"
+    kubernetes = "~> 2.11.0"
+    helm       = "~> 2.10.1"
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = ">= 1.7.0"

--- a/aws/efs/versions.tf
+++ b/aws/efs/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws        = "~> 3.68.0"
+    aws        = ">= 4.0.0"
   }
 }

--- a/aws/eks/versions.tf
+++ b/aws/eks/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws        = "~> 3.68.0"
+    aws        = ">= 4.0.0"
   }
 }

--- a/aws/vpc/versions.tf
+++ b/aws/vpc/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws        = "~> 3.68.0"
+    aws        = ">= 4.0.0"
   }
 }


### PR DESCRIPTION
helm and k8s versions of CSI driver are old and should be updated.