### PR TITLE
Chore: upgrade helm and k8s TF provider versions

### DIFF
--- a/aws/csi-driver/versions.tf
+++ b/aws/csi-driver/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws        = "~> 3.68.0"
-    kubernetes = "~> 2.7.0"
-    helm       = "~> 2.4.0"
+    kubernetes = "~> 2.11.0"
+    helm       = "~> 2.10.1"
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = ">= 1.7.0"

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     google     = "~> 4.7.0"
-    kubernetes = "~> 2.7.0"
-    helm       = "~> 2.4.0"        
+    kubernetes = "~> 2.11.0"
+    helm       = "~> 2.10.1"
   }
 }


### PR DESCRIPTION
Upgrade `helm` from `2.4.0` to `2.10.1`
Upgrade `kubernetes` from `2.7.0` to `2.11.0`

Verified that there aren't breaking changes