### PR TITLE
Core - node disk size

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -26,7 +26,17 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     ami_type  = "AL2_x86_64"
-    disk_size = 50
+
+    block_device_mappings = {
+      xvda = {
+        device_name = "/dev/xvda"
+        ebs = {
+          volume_size           = 50
+          volume_type           = "gp3"
+          delete_on_termination = true
+        }
+      }
+    }
   }
 
   eks_managed_node_groups = {


### PR DESCRIPTION
https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest/submodules/eks-managed-node-group
```
Note: `disk_size`, and `remote_access` can only be set when using the EKS managed node group default launch template
This module defaults to providing a custom launch template to allow for custom security groups, tag propagation, etc.
```

so replace it with `block_device_mappings`