### PR TITLE
Chore - more instance types

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -54,8 +54,8 @@ module "eks" {
         max_unavailable_percentage = 50
       }
 
-      instance_types = [var.instance_type]
-      capacity_type  = "SPOT"
+      instance_types = var.instance_types
+      capacity_type  = var.capacity_type
     }
   }
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -16,8 +16,18 @@ variable "min_capacity" {
   default     = 2
 }
 
-variable "instance_type" {
-  default = "t3a.2xlarge" # 8vCPUs 32GB
+variable "instance_types" {
+  default = [
+    "t3a.2xlarge",
+    "t3a.xlarge",
+    "t3.2xlarge",
+    "t3.xlarge"
+  ]
+  type = list(string)
+}
+
+variable "capacity_type" {
+  default = "SPOT"
 }
 
 variable "cluster_access_entries" {}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -27,7 +27,7 @@ module "eks" {
   subnet_ids = module.vpc.private_subnet_ids
 
   min_capacity  = var.min_capacity
-  instance_type = var.instance_types
+  instance_types = var.instance_types
   capacity_type = var.capacity_type
 
   cluster_access_entries = var.cluster_access_entries

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -27,14 +27,15 @@ module "eks" {
   subnet_ids = module.vpc.private_subnet_ids
 
   min_capacity  = var.min_capacity
-  instance_type = var.instance_type
+  instance_type = var.instance_types
+  capacity_type = var.capacity_type
 
   cluster_access_entries = var.cluster_access_entries
 }
 
 module "autoscaler" {
   depends_on = [module.eks]
-  source     = "./autoscaler"
+  source = "./autoscaler"
 
   cluster_name            = var.cluster_name
   managed_node_group_name = module.eks.managed_node_group_name
@@ -44,18 +45,18 @@ module "autoscaler" {
 
 module "efs" {
   depends_on = [module.eks, module.vpc]
-  source     = "./efs"
+  source = "./efs"
 
-  region                     = var.region
-  vpc_id                     = local.vpc_id
-  cluster_name               = var.cluster_name
-  subnets                    = module.vpc.private_subnet_ids
+  region       = var.region
+  vpc_id       = local.vpc_id
+  cluster_name = var.cluster_name
+  subnets      = module.vpc.private_subnet_ids
   allowed_security_group_ids = [module.eks.node_security_group_id, module.eks.cluster_security_group_id]
 }
 
 module "efs_csi_driver" {
   depends_on = [module.eks]
-  source     = "./csi-driver"
+  source = "./csi-driver"
 
   efs_id         = module.efs.efs_id
   reclaim_policy = var.reclaim_policy
@@ -66,7 +67,7 @@ module "efs_csi_driver" {
 
 module "calico" {
   depends_on = [module.eks]
-  source     = "./calico"
+  source = "./calico"
 
   count = var.enable_calico ? 1 : 0
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,8 +1,8 @@
 ## VPC
 variable "azs" {
   description = "A list of availability zones names or ids in the region"
-  type        = list(string)
-  default     = []
+  type = list(string)
+  default = []
 }
 
 variable "cidr" {
@@ -41,8 +41,18 @@ variable "min_capacity" {
   default     = 2
 }
 
-variable "instance_type" {
-  default = "t3a.2xlarge" # 8vCPUs 32GB
+variable "instance_types" {
+  default = [
+    "t3a.2xlarge",
+    "t3a.xlarge",
+    "t3.2xlarge",
+    "t3.xlarge"
+  ]
+  type = list(string)
+}
+
+variable "capacity_type" {
+  default = "SPOT"
 }
 
 variable "region" {


### PR DESCRIPTION
### Problem

Our node group fails to scale with following error

```
Launching a new EC2 instance. Status Reason: Could not launch Spot Instances.
UnfulfillableCapacity - Unable to fulfill capacity due to your request configuration.
Please adjust your request and try again. Launching EC2 instance failed.
```

### Solution
Add more instance types to choose from
