### PR TITLE
Chore: Pin the eks module version

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "20.31.4"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version


### PR DESCRIPTION
### why
each time we are running the drift detection if there's a new version of the module there's a potential of drift.

### what
pin the version to latest