### PR TITLE
Chore: Make k8s version required

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -61,7 +61,6 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      version  = "v1.11.3-eksbuild.1"
       preserve = true
 
       timeouts = {
@@ -69,12 +68,8 @@ module "eks" {
         delete = "10m"
       }
     }
-    kube-proxy = {
-      version = "v1.31.2-eksbuild.3"
-    }
-    vpc-cni = {
-      version = "v1.19.0-eksbuild.1"
-    }
+    kube-proxy = {}
+    vpc-cni    = {}
   }
 
   create_kms_key            = false

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -25,9 +25,7 @@ variable "public_subnets_cidr_blocks" {
 
 variable "cluster_name" {}
 
-variable "kubernetes_version" {
-  default = "1.31"
-}
+variable "kubernetes_version" {}
 
 variable "cluster_access_entries" {
   description = "Map of access entries to add to the cluster"


### PR DESCRIPTION
### Problem
Having a default k8s can be confusing we prefer the variable to be required instead

### Solution
Remove the default k8s version + remove the add-ons' version since they are already being automatically calculated

### QA
- [x] See plan for the current state isn't being changed
![image](https://github.com/user-attachments/assets/6e00c133-3d20-4dca-bb99-7163af527e31)

- [x]  See a new plan is being calculated to the computed versions as the current state
![image](https://github.com/user-attachments/assets/729411c9-faf1-4050-ab49-004f33ff4a23)
