### PR TITLE
Chore: Allow docker hub credentials for Calico

### DIFF
--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -29,7 +29,7 @@ resource "helm_release" "calico" {
   }
 
   dynamic "set_sensitive" {
-    for_each = local.docker_config != null ? [base64encode(jsonencode(local.docker_config))] : []
+    for_each = local.docker_config != null ? [jsonencode(local.docker_config)] : []
     iterator = config
     content {
       name  = "imagePullSecrets"

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "calico" {
     iterator = config
     content {
       name  = "imagePullSecrets"
-      value = config.value
+      value = "\"${config.value}\""
     }
   }
 }

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -13,4 +13,11 @@ resource "helm_release" "calico" {
     name = "apiServer.enabled"
     value = "false"
   }
+
+  set {
+    name = "imagePullSecrets"
+    value = jsonencode({
+      "calico-image-pull-secret" = var.calico_image_pull_secret
+    })
+  }
 }

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -16,25 +16,28 @@ resource "helm_release" "calico" {
 
   dynamic "set" {
     for_each = var.calico_docker_hub_credentials != null ? [var.calico_docker_hub_credentials] : []
+    iterator = cred
     content {
       name  = "imagePullSecrets[0].username"
-      value = set.value.username
+      value = cred.value.username
     }
   }
 
   dynamic "set_sensitive" {
     for_each = var.calico_docker_hub_credentials != null ? [var.calico_docker_hub_credentials] : []
+    iterator = cred
     content {
       name  = "imagePullSecrets[0].password"
-      value = set.value.password
+      value = cred.value.password
     }
   }
 
   dynamic "set" {
     for_each = var.calico_docker_hub_credentials != null ? [var.calico_docker_hub_credentials] : []
+    iterator = cred
     content {
       name  = "imagePullSecrets[0].email"
-      value = set.value.email
+      value = cred.value.email
     }
   }
 

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -29,11 +29,11 @@ resource "helm_release" "calico" {
   }
 
   dynamic "set_sensitive" {
-    for_each = local.docker_config != null ? [jsonencode(local.docker_config)] : []
+    for_each = local.docker_config != null ? [jsonencode({ "calico-image-pull-secret": local.docker_config })] : []
     iterator = config
     content {
       name  = "imagePullSecrets"
-      value = "\"${config.value}\""
+      value = config.value
     }
   }
 }

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -1,3 +1,18 @@
+locals {
+  image_pull_secrets = {
+    "calico-image-pull-secret": jsonencode({
+      auths = {
+        "docker.io" = {
+          username = var.calico_docker_hub_credentials.username,
+          password = var.calico_docker_hub_credentials.password,
+          email    = var.calico_docker_hub_credentials.email,
+          auth     = base64encode("${var.calico_docker_hub_credentials.username}:${var.calico_docker_hub_credentials.password}")
+        }
+      }
+    })
+  }
+}
+
 resource "helm_release" "calico" {
   repository = "https://docs.projectcalico.org/charts/"
   chart      = "tigera-operator"
@@ -17,20 +32,7 @@ resource "helm_release" "calico" {
             enabled = false
           }
         },
-          var.calico_docker_hub_credentials != null ? {
-          imagePullSecrets = {
-            "calico-image-pull-secret": jsonencode({
-              auths = {
-                "docker.io" = {
-                  username = var.calico_docker_hub_credentials.username,
-                  password = var.calico_docker_hub_credentials.password,
-                  email    = var.calico_docker_hub_credentials.email,
-                  auth     = base64encode("${var.calico_docker_hub_credentials.username}:${var.calico_docker_hub_credentials.password}")
-                }
-              }
-            })
-          }
-        } : {}
+          var.calico_docker_hub_credentials != null ? { imagePullSecrets = local.image_pull_secrets  } : {}
       )
     )
   ]

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -18,7 +18,7 @@ resource "helm_release" "calico" {
           }
         },
           var.calico_docker_hub_credentials != null ? {
-          imagePullSecrets = {
+          imagePullSecrets = jsonencode({
             auths = {
               "docker.io" = {
                 username = var.calico_docker_hub_credentials.username,
@@ -27,7 +27,7 @@ resource "helm_release" "calico" {
                 auth     = base64encode("${var.calico_docker_hub_credentials.username}:${var.calico_docker_hub_credentials.password}")
               }
             }
-          }
+          })
         } : {}
       )
     )

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -18,16 +18,18 @@ resource "helm_release" "calico" {
           }
         },
           var.calico_docker_hub_credentials != null ? {
-          imagePullSecrets = jsonencode({
-            auths = {
-              "docker.io" = {
-                username = var.calico_docker_hub_credentials.username,
-                password = var.calico_docker_hub_credentials.password,
-                email    = var.calico_docker_hub_credentials.email,
-                auth     = base64encode("${var.calico_docker_hub_credentials.username}:${var.calico_docker_hub_credentials.password}")
+          imagePullSecrets = {
+            "calico-image-pull-secret": jsonencode({
+              auths = {
+                "docker.io" = {
+                  username = var.calico_docker_hub_credentials.username,
+                  password = var.calico_docker_hub_credentials.password,
+                  email    = var.calico_docker_hub_credentials.email,
+                  auth     = base64encode("${var.calico_docker_hub_credentials.username}:${var.calico_docker_hub_credentials.password}")
+                }
               }
-            }
-          })
+            })
+          }
         } : {}
       )
     )

--- a/aws/calico/main.tf
+++ b/aws/calico/main.tf
@@ -14,10 +14,28 @@ resource "helm_release" "calico" {
     value = "false"
   }
 
-  set {
-    name = "imagePullSecrets"
-    value = jsonencode({
-      "calico-image-pull-secret" = var.calico_image_pull_secret
-    })
+  dynamic "set" {
+    for_each = var.calico_docker_hub_credentials != null ? [var.calico_docker_hub_credentials] : []
+    content {
+      name  = "imagePullSecrets[0].username"
+      value = set.value.username
+    }
   }
+
+  dynamic "set_sensitive" {
+    for_each = var.calico_docker_hub_credentials != null ? [var.calico_docker_hub_credentials] : []
+    content {
+      name  = "imagePullSecrets[0].password"
+      value = set.value.password
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.calico_docker_hub_credentials != null ? [var.calico_docker_hub_credentials] : []
+    content {
+      name  = "imagePullSecrets[0].email"
+      value = set.value.email
+    }
+  }
+
 }

--- a/aws/calico/variables.tf
+++ b/aws/calico/variables.tf
@@ -1,5 +1,10 @@
-variable "calico_image_pull_secret" {
-    description = "The image pull secret for Calico"
+variable "calico_docker_hub_credentials" {
+    description = "Docker Hub credentials"
+    type = object({
+        username = string
+        password = string
+        email    = string
+    })
     default = null
-    type = map(string)
+    sensitive = true
 }

--- a/aws/calico/variables.tf
+++ b/aws/calico/variables.tf
@@ -1,0 +1,5 @@
+variable "calico_image_pull_secret" {
+    description = "The image pull secret for Calico"
+    default = null
+    type = map(string)
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -69,5 +69,5 @@ module "calico" {
   source = "./calico"
 
   count = var.enable_calico ? 1 : 0
-  calico_image_pull_secret = var.calico_image_pull_secret
+  calico_docker_hub_credentials = var.calico_docker_hub_credentials
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,6 +1,5 @@
 locals {
   vpc_id                             = module.vpc.vpc_id
-  efs_id                             = module.efs.efs_id
   cluster_certificate_authority_data = module.eks.cluster_certificate_authority_data
   cluster_endpoint                   = module.eks.cluster_endpoint
 }
@@ -70,4 +69,5 @@ module "calico" {
   source = "./calico"
 
   count = var.enable_calico ? 1 : 0
+  calico_image_pull_secret = var.calico_image_pull_secret
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -67,3 +67,9 @@ variable "enable_calico" {
   default     = false
   type        = bool
 }
+
+variable "calico_image_pull_secret" {
+  description = "The image pull secret for Calico"
+  default = null
+  type = map(string)
+}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -68,8 +68,13 @@ variable "enable_calico" {
   type        = bool
 }
 
-variable "calico_image_pull_secret" {
-  description = "The image pull secret for Calico"
+variable "calico_docker_hub_credentials" {
+  description = "Docker Hub credentials"
+  type = object({
+    username = string
+    password = string
+    email    = string
+  })
   default = null
-  type = map(string)
+  sensitive = true
 }


### PR DESCRIPTION
Support a new variable called `calico_docker_hub_credentials` that sets the docker hub credentials by calico to fetch docker images.

Already deployed the stack with and without this value to make sure it works.