### PR TITLE
Chore: support EKS max capacity

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -48,7 +48,7 @@ module "eks" {
 
       min_size     = var.min_capacity
       desired_size = var.min_capacity
-      max_size     = 50
+      max_size     = var.max_capacity
 
       update_config = {
         max_unavailable_percentage = 50

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -47,6 +47,7 @@ module "eks" {
       use_name_prefix = false
 
       min_size     = var.min_capacity
+      desired_size = 2
       max_size     = var.max_capacity
 
       update_config = {

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -47,7 +47,6 @@ module "eks" {
       use_name_prefix = false
 
       min_size     = var.min_capacity
-      desired_size = var.min_capacity
       max_size     = var.max_capacity
 
       update_config = {

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -47,7 +47,7 @@ module "eks" {
       use_name_prefix = false
 
       min_size     = var.min_capacity
-      desired_size = 2
+      desired_size = var.min_capacity
       max_size     = var.max_capacity
 
       update_config = {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -16,6 +16,11 @@ variable "min_capacity" {
   default     = 2
 }
 
+variable "max_capacity" {
+  description = "Max number of workers"
+  default = 20
+}
+
 variable "instance_types" {
   default = [
     "t3a.2xlarge",

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -26,6 +26,7 @@ module "eks" {
   subnet_ids = module.vpc.private_subnet_ids
 
   min_capacity  = var.min_capacity
+  max_capacity = var.max_capacity
   instance_types = var.instance_types
   capacity_type = var.capacity_type
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -39,6 +39,11 @@ variable "min_capacity" {
   default     = 2
 }
 
+variable "max_capacity" {
+  description = "Max number of workers"
+  default = 20
+}
+
 variable "instance_types" {
   default = [
     "t3a.2xlarge",


### PR DESCRIPTION
Add a max capacity variable (defaults to 20) for the EKS cluster to control the EKS cluster's node max capacity