### PR TITLE
Fix - add providers version constraints

### DIFF
--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -4,6 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 5.40.0, < 6.0.0"
     helm       = ">= 2.13.0, < 3.0.0"
-    kubernetes = ">= 2.29.0"
+    kubernetes = ">= 2.29.0, < 3.0.0"
   }
 }

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
-    aws        = ">= 5.40.0"
-    helm       = ">= 2.13.0"
+    aws        = ">= 5.40.0, < 6.0.0"
+    helm       = ">= 2.13.0, < 3.0.0"
     kubernetes = ">= 2.29.0"
   }
 }


### PR DESCRIPTION
aws provider 6.x and helm provider 3.x are not compatible
add constraints to the providers versions